### PR TITLE
Support for UTF-8  encoding of PG files (and warnings)

### DIFF
--- a/lib/RenderApp/Controller/FormatRenderedProblem.pm
+++ b/lib/RenderApp/Controller/FormatRenderedProblem.pm
@@ -106,7 +106,9 @@ sub formatRenderedProblem {
 
 	if ( defined ($rh_result->{WARNINGS}) and $rh_result->{WARNINGS} ){
 		$warnings = "<div style=\"background-color:pink\">
-		             <p >WARNINGS</p><p>".decode_base64($rh_result->{WARNINGS})."</p></div>";
+		             <p >WARNINGS</p><p>"
+		             . Encode::decode("UTF-8", decode_base64($rh_result->{WARNINGS}) )
+		             . "</p></div>";
 	}
 	#warn "keys: ", join(" | ", sort keys %{$rh_result });
 

--- a/lib/RenderApp/Controller/IO.pm
+++ b/lib/RenderApp/Controller/IO.pm
@@ -53,7 +53,7 @@ sub writer {
       };
     my $validatedInput = $c->validateRequest( { required => $required } );
     return unless $validatedInput;
-    my $source    = decode_base64( $validatedInput->{problemSource} );
+    my $source = Encode::decode("UTF-8",decode_base64( $validatedInput->{problemSource} ) );
     my $file_path = $validatedInput->{writeFilePath};
 
     if ( $source =~ /^\s*$/ ) {

--- a/lib/RenderApp/Controller/RenderProblem.pm
+++ b/lib/RenderApp/Controller/RenderProblem.pm
@@ -122,7 +122,7 @@ sub process_pg_file {
         renderedHTML => $html,
         answers      => $pg_obj->{answers},
         debug        => {
-            perl_warn => decode_base64( $pg_obj->{WARNINGS} ),
+            perl_warn => Encode::decode("UTF-8", decode_base64( $pg_obj->{WARNINGS} ) ),
             pg_warn   => $pg_obj->{warning_messages},
             debug     => $pg_obj->{debug_messages},
             internal  => $pg_obj->{internal_debug_messages}
@@ -171,7 +171,7 @@ sub process_problem {
     # if base64 source is provided, use that over fetching problem path
     if ( $inputs_ref->{problemSource} && $inputs_ref->{problemSource} =~ m/\S/ )
     {
-        $source = decode_base64( $inputs_ref->{problemSource} );
+        $source = Encode::decode("UTF-8",decode_base64( $inputs_ref->{problemSource} ) );
     }
     else {
         ( $adj_file_path, $source ) = get_source($file_path);
@@ -405,7 +405,7 @@ sub standaloneRenderer {
         header_text             => $pg->{head_text},
         answers                 => $pg->{answers},
         errors                  => $pg->{errors},
-        WARNINGS                => encode_base64( $pg->{warnings} ),
+        WARNINGS                => encode_base64( Encode::encode("UTF-8", $pg->{warnings} ) ),
         PG_ANSWERS_HASH         => $pg->{pgcore}->{PG_ANSWERS_HASH},
         problem_result          => $pg->{result},
         problem_state           => $pg->{state},

--- a/lib/RenderApp/Model/Problem.pm
+++ b/lib/RenderApp/Model/Problem.pm
@@ -172,7 +172,7 @@ sub save {
 
     return 0 unless $self->success();
 
-    $write_path->spurt( $self->{problem_contents} );
+    $write_path->spurt( Encode::encode('UTF-8', $self->{problem_contents} ) );
     $self->path($write_path);    # update the read_path to match
     return 1;
 }
@@ -182,7 +182,7 @@ sub load {
     my $success   = 0;
     my $read_path = $self->{read_path};
     if ( -r $read_path ) {
-        $self->{problem_contents} = $read_path->slurp;
+        $self->{problem_contents} = Encode::decode( "UTF-8", $read_path->slurp );
         $success = 1;
     }
     else {

--- a/public/navbar.js
+++ b/public/navbar.js
@@ -161,7 +161,19 @@ function insertListener() {
     formData.set("format", "json");
     formData.set("outputformat", document.querySelector(".dropdown-item.selected").id);
     formData.set(clickedButton.name, clickedButton.value);
-    formData.set("problemSource", window.btoa(cm.getValue()));
+
+//  // Version tracking steps to replace window.btoa with code supporting Unicode text
+//  encoder = new TextEncoder();
+//  let text16 = cm.getValue();
+//  let text8array = encoder.encode(text16);
+//  console.log( text8array );
+//  let textbase64 = Base64.fromUint8Array( text8array );
+//  console.log( textbase64 );
+//  formData.set("problemSource", textbase64 );
+
+    encoder = new TextEncoder();
+    formData.set("problemSource", Base64.fromUint8Array(encoder.encode(cm.getValue())));
+
     [...document.querySelectorAll('.checkbox-input:checked')].map(e => e.name).forEach((box) => {
       formData.append(box, 1);
     });

--- a/public/navbar.js
+++ b/public/navbar.js
@@ -25,7 +25,19 @@ savebutton.addEventListener("click", event => {
   const writeurl = '/render-api/can'
 
   let formData = new FormData()
-  formData.set("problemSource", window.btoa(cm.getValue()))
+
+//  // Version tracking steps to replace window.btoa with code supporting Unicode text
+//  encoder = new TextEncoder();
+//  let text16 = cm.getValue();
+//  let text8array = encoder.encode(text16);
+//  console.log( text8array );
+//  let textbase64 = Base64.fromUint8Array( text8array );
+//  console.log( textbase64 );
+//  formData.set("problemSource", textbase64 );
+
+  encoder = new TextEncoder();
+  formData.set("problemSource", Base64.fromUint8Array(encoder.encode(cm.getValue())));
+
   formData.set("writeFilePath", document.getElementById('sourceFilePath').value)
   const write_params = {
     body : formData,
@@ -85,7 +97,19 @@ renderbutton.addEventListener("click", event => {
   formData.set("sourceFilePath", document.getElementById('sourceFilePath').value);
   formData.set("problemSeed", document.getElementById('problemSeed').value);
   formData.set("outputformat", document.querySelector(".dropdown-item.selected").id);
-  formData.set("problemSource", window.btoa(cm.getValue()));
+
+//  // Version tracking steps to replace window.btoa with code supporting Unicode text
+//  encoder = new TextEncoder();
+//  let text16 = cm.getValue();
+//  let text8array = encoder.encode(text16);
+//  console.log( text8array );
+//  let textbase64 = Base64.fromUint8Array( text8array );
+//  console.log( textbase64 );
+//  formData.set("problemSource", textbase64 );
+
+  encoder = new TextEncoder();
+  formData.set("problemSource", Base64.fromUint8Array(encoder.encode(cm.getValue())));
+
   [...document.querySelectorAll('.checkbox-input:checked')].map(e => e.name).forEach( (box) => {
     formData.append(box, 1);
   });

--- a/templates/login/ui.html.ep
+++ b/templates/login/ui.html.ep
@@ -1,6 +1,7 @@
 % layout 'navbar';
 %= stylesheet '/twocolumn.css'
 %= javascript '/iframeResizer.min.js'
+%= javascript 'https://cdn.jsdelivr.net/npm/js-base64@3.5.2/base64.min.js'
 <div class="row">
   <div class="column" style="background-color:#aaa;">
     %= include 'login/editorUI'


### PR DESCRIPTION
This is a revised branch of changes to add support for UTF-8 encoded PG files.
  - Use of UTF-8 is supported by WW 2.15 and PG 2.15, and has been in production use for over a year on several WW servers.
If relates to issue https://github.com/rederly/renderer/issues/7 .
It replaces the branch:  https://github.com/taniwallach/renderer/tree/utf8-support-v1 which was not used in a PR.
One of the commits from the old branch could be used "as is" in a rebase to the current (as of 2021-JAN-18) version of rederly/renderer master. The other 2 and some additional changes are in a new commit in this branch.

---

The rederly front-end apparently also needs to take UTF-8 support into account.
See: https://github.com/rederly/frontend/pull/248#discussion_r515628919

There is also use of `btoa` and `atob` which do not support Unicode in `src/Extensions/StringExtension.ts` of the frontend:
  - https://github.com/rederly/frontend/blob/22898db8103fafc732df02e0a1f4d5e3cccaab54/src/Extensions/StringExtension.ts#L19
  - https://github.com/rederly/frontend/blob/22898db8103fafc732df02e0a1f4d5e3cccaab54/src/Extensions/StringExtension.ts#L14
  - https://github.com/rederly/frontend/blob/22898db8103fafc732df02e0a1f4d5e3cccaab54/src/Extensions/StringExtension.ts#L19

@doombot-exe @red-tt-bear - Please look into the UTF-8 issues in the frontend so that the UTF-8 support can be added to the renderer.